### PR TITLE
fix(helpers/logger): persist telegraph token and skip empty log upload

### DIFF
--- a/ub_core/core/client.py
+++ b/ub_core/core/client.py
@@ -104,6 +104,15 @@ class BOT(CustomDecorators, Methods, pyrogram.Client):
     async def shut_down(self) -> None:
         """Gracefully ShutDown all Processes"""
         LOGGER.info("Stopping all processes...")
+        
+        try:
+            if "app.webui.server" in sys.modules:
+                await sys.modules["app.webui.server"].webui_manager.stop()
+            if "app.plugins.misc.webui" in sys.modules:
+                sys.modules["app.plugins.misc.webui"].terminate_tunnel()
+        except Exception as e:
+            LOGGER.error(f"Failed to stop WebUI hooks: {e}")
+
         await Config.TASK_MANAGER.close_and_run_exit_tasks()
         await super().stop()
         LOGGER.info("Exiting...")

--- a/ub_core/core/logging/cmd_usage_logger.py
+++ b/ub_core/core/logging/cmd_usage_logger.py
@@ -40,8 +40,9 @@ async def upload_usage_record():
     if Config.COMMAND_LOG_LEVEL == 0:
         return
 
-    if not LOG_FILE.is_file():
+    if not LOG_FILE.is_file() or LOG_FILE.stat().st_size == 0:
         return
+
     await bot.send_document(
         chat_id=Config.LOG_CHAT,
         message_thread_id=Config.LOG_CHAT_THREAD_ID,

--- a/ub_core/utils/helpers.py
+++ b/ub_core/utils/helpers.py
@@ -3,6 +3,7 @@ import logging
 import time
 from collections import defaultdict
 from inspect import isawaitable, iscoroutine, iscoroutinefunction
+from pathlib import Path
 from typing import Any
 
 from pyrogram.enums import ParseMode
@@ -14,6 +15,7 @@ from ..config import Config
 
 TELEGRAPH: None | Telegraph = None
 
+_TELEGRAPH_TOKEN_FILE = Path(".telegraph_token")
 
 PROGRESS_DICT: dict[str, dict[str, float]] = defaultdict(lambda: {"start_time": (t := time.time()), "progress_time": t})
 
@@ -23,10 +25,20 @@ LOGGER = logging.getLogger(Config.BOT_NAME)
 async def init_task():
     global TELEGRAPH
     TELEGRAPH = Telegraph()
+
+    if _TELEGRAPH_TOKEN_FILE.is_file():
+        token = _TELEGRAPH_TOKEN_FILE.read_text().strip()
+        if token:
+            TELEGRAPH = Telegraph(access_token=token)
+            return
+
     try:
         await TELEGRAPH.create_account(
             short_name=Config.BOT_NAME, author_name=Config.BOT_NAME, author_url=Config.UPSTREAM_REPO
         )
+        token = TELEGRAPH.get_access_token()
+        if token:
+            _TELEGRAPH_TOKEN_FILE.write_text(token)
     except Exception as e:
         LOGGER.error(f"Failed to Create Telegraph Account: {e}")
 


### PR DESCRIPTION
- helpers.py: save telegraph access token to .telegraph_token on first boot and reuse it on subsequent starts, avoiding a blocking HTTP call to create_account() every restart. also remove erroneous await on sync get_access_token().

- cmd_usage_logger.py: add st_size == 0 guard alongside is_file() check to prevent send_document raising ValueError on empty log file.